### PR TITLE
Use --repository_url to override the git origin URL

### DIFF
--- a/rbtools/postreview.py
+++ b/rbtools/postreview.py
@@ -3740,7 +3740,7 @@ def parse_options(args):
                       help="the url for a repository for creating a diff "
                            "outside of a working copy (currently only "
                            "supported by Subversion with --revision-range or "
-                           "--diff-filename, ClearCase with relative "
+                           "--diff-filename and ClearCase with relative "
                            "paths outside the view). for git, this specifies"
                            "the origin url of the current repository, "
                            "overriding the origin url supplied by the git client.")


### PR DESCRIPTION
This patch allows the user to override the current git repository's origin URL by setting --repository_url.
