### PR TITLE
Accept a single revision id for --revision-range for Mercurial repositories

### DIFF
--- a/rbtools/clients/mercurial.py
+++ b/rbtools/clients/mercurial.py
@@ -265,7 +265,20 @@ class MercurialClient(SCMClient):
         if self._type != 'hg':
             raise NotImplementedError
 
-        r1, r2 = revision_range.split(':')
+        if ':' not in revision_range:
+            # if only 1 revision is given, we find the first parent and use
+            # that as the second revision.
+            # we could also use "hg diff -c r1", but then we couldn't reuse the
+            # code for extracting descriptions.
+            r2 = revision_range
+            r1 = execute([
+                "hg", "parents",
+                "-r", r2,
+                "--template", "{rev}\n",
+            ]).split()[0]
+
+        else:
+            r1, r2 = revision_range.split(':')
 
         if self._options.guess_summary and not self._options.summary:
             self._options.summary = self.extract_summary(r2)


### PR DESCRIPTION
On http://www.reviewboard.org/docs/manual/dev/users/tools/post-review/#posting-committed-code, it claims that you can use a single revision id for --revision-range. However, it didn’t work when I tried it, so I made it work.

You’re welcome.
