### PR TITLE
Fixed typo in ADD_REPOSITORY_DOCS_URL to show current docs directory

### DIFF
--- a/rbtools/postreview.py
+++ b/rbtools/postreview.py
@@ -100,7 +100,7 @@ options = None
 configs = []
 
 ADD_REPOSITORY_DOCS_URL = \
-    'http://www.reviewboard.org/docs/manual/dev/admin/management/repositories/'
+    'http://www.reviewboard.org/docs/manual/dev/admin/configuration/repositories/'
 
 
 class HTTPRequest(urllib2.Request):


### PR DESCRIPTION
Due to changed URL structure on reviewboard website, this variable should be updated.
