### PR TITLE
Disable submodule diffing in Git client.

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -262,7 +262,7 @@ class GitClient(SCMClient):
             return self.make_svn_diff(ancestor, diff_lines)
         elif self.type == "git":
             return execute([self.git, "diff", "--no-color", "--full-index",
-                            "--no-ext-diff", rev_range])
+                            "--no-ext-diff", "--ignore-submodules", rev_range])
 
         return None
 


### PR DESCRIPTION
ReviewBoard's diff parser can't handle submodule differences, so it's better to just exclude them from the diff so that posting a review doesn't just result in an error.
