### PR TITLE
.reviewboardrc in HOME has no effect.

### DIFF
--- a/rbtools/utils/filesystem.py
+++ b/rbtools/utils/filesystem.py
@@ -53,7 +53,11 @@ def load_config_files(homepath):
         if config:
             configs.append(config)
 
-    return _load_config(homepath), configs
+    user_config = _load_config(homepath)
+    if user_config:
+        configs.append(user_config)
+
+    return user_config, configs
 
 
 def make_tempfile(content=None):


### PR DESCRIPTION
BUG:
    If the user has set up only one .reviewboardrc in
    his/hers home directory, it will not be included in the
    search path for configs. It's contents is returned from
    load_config_files() and assigned to user_configs in main. How ever
    this variable is never used in parse_options().

FIX:
    Add the HOME path to the search path for global configs.
