### PR TITLE
A fix for the issue treating svn repo as perforce by mistake

### DIFF
--- a/rbtools/clients/__init__.py
+++ b/rbtools/clients/__init__.py
@@ -138,9 +138,9 @@ def load_scmclients(options):
         ClearCaseClient(options=options),
         GitClient(options=options),
         MercurialClient(options=options),
+        SVNClient(options=options),
         PerforceClient(options=options),
         PlasticClient(options=options),
-        SVNClient(options=options),
     ]
 
 


### PR DESCRIPTION
This issue occurred when post-review in an svn repo while p4 client is
also installed. Since p4 tool is checked in prio, the svn repo will be
treated in p4 way and an error message will be prompted. It would be
better we consider svn whose metadata is stored locally in prio to p4
whose metadata is stored on server side.
