### PR TITLE
Support repository_url option when using Bazaar

### DIFF
--- a/rbtools/clients/bazaar.py
+++ b/rbtools/clients/bazaar.py
@@ -45,6 +45,9 @@ class BazaarClient(SCMClient):
             if path == ".":
                 path = os.getcwd()
             
+            if self.options.repository_url:
+                path = self.options.repository_url
+            
             repository_info = RepositoryInfo(
                 path=path,
                 base_path="/",    # Diffs are always relative to the root.


### PR DESCRIPTION
This is a small patch to add repository_url support to the Bazaar client. With this change, Bazaar client support works well enough to be useful at the company where I work.
