### PR TITLE
Fix git parent diff support in diff_between_revisions

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -496,7 +496,7 @@ class GitClient(SCMClient):
 
         return {
             'diff': diff_lines,
-            'parent_diff_lines': parent_diff_lines,
+            'parent_diff': parent_diff_lines,
             'base_commit_id': self.merge_base,
         }
 

--- a/rbtools/clients/tests.py
+++ b/rbtools/clients/tests.py
@@ -63,6 +63,12 @@ class GitClientTests(SCMClientTests):
         if not self.is_exe_in_path('git'):
             raise SkipTest('git not found in path')
 
+        gitconfig = open(os.path.join(self.get_user_home(), '.gitconfig'), 'w')
+        gitconfig.write("[user]\n")
+        gitconfig.write("\tname = test\n")
+        gitconfig.write("\temail = test@test.com\n")
+        gitconfig.close()
+
         self.git_dir = self.chdir_tmp()
         self._gitcmd(['init'], git_dir=self.git_dir)
         foo = open(os.path.join(self.git_dir, 'foo.txt'), 'w')


### PR DESCRIPTION
The calling contract stipulates that the parent diff should be in a
dictionary entry called 'parent_diff', not 'parent_diff_lines'.

I also snuck in a change to the git unit tests: if they don't create a
dummy .gitconfig in the new HOME, "git commit" dies later, triggering all
sorts of unhappiness in nose.
