### PR TITLE
Stop args from containing a single empty string

### DIFF
--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -136,6 +136,9 @@ class Command(object):
         parser = self.create_parser(self.config)
         options, args = parser.parse_args(argv[2:])
         self.options = options
+        # 'args' can sometimes contain an empty string. This will confuse
+        # tools if we pass it around
+        args.remove('')
 
         # Check that the proper number of arguments have been provided.
         argspec = inspect.getargspec(self.main)


### PR DESCRIPTION
Sometimes (I haven't tracked down quite where) OptionParser will return
args as ['']. This can get interpreted as a revision range by the clients
(in particular git), which can confuse matters - the git client tries to
run `git rev-parse`, which fails, for instance.

Therefore remove emptystring from the args return from OptionParser.

Untested on any clients except git.
