### PR TITLE
Added ability to update by changenum

### DIFF
--- a/rbtools/clients/__init__.py
+++ b/rbtools/clients/__init__.py
@@ -17,6 +17,7 @@ class SCMClient(object):
     name = None
 
     supports_diff_extra_args = False
+    supports_update_without_summary_and_description = False
 
     def __init__(self, user_config=None, configs=[], options=None,
                  capabilities=None):
@@ -224,6 +225,16 @@ class SCMClient(object):
         ``None`` should be returned.
         """
         raise NotImplementedError
+
+    def match_existing_review_request(self, review_requests, revisions):
+        """Scan the given review_requests for one that matches the given 
+        revisions and return it.  If an exact match is not found, return 
+        ``None``.
+
+        Derived classes should override this method if they are able to
+        uniquely match existing reviews to particular revisions.
+        """
+        return None
 
 
 class RepositoryInfo(object):

--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -163,6 +163,7 @@ class PerforceClient(SCMClient):
     name = 'Perforce'
 
     supports_diff_extra_args = True
+    supports_update_without_summary_and_description = True
 
     DATE_RE = re.compile(r'(\w+)\s+(\w+)\s+(\d+)\s+(\d\d:\d\d:\d\d)\s+'
                          '(\d\d\d\d)')
@@ -378,6 +379,18 @@ class PerforceClient(SCMClient):
             if 'Status' in change[0]:
                 return change[0]['Status']
 
+        return None
+        
+    def match_existing_review_request(self, review_requests, revisions):
+        """Scan the given review_requests for one that matches the given 
+        revisions and return it.  If an exact match is not found, return 
+        ``None``.
+        """
+        tip = revisions['tip']
+        changenum = int(tip.replace(self.REVISION_PENDING_CLN_PREFIX, ''))
+        for review_request in review_requests:
+            if changenum == review_request.changenum:
+                return review_request
         return None
 
     def scan_for_server(self, repository_info):


### PR DESCRIPTION
Some SMCs (like Perforce) may be able to update reviews without having to compare summaries and descriptions by using the changenum directly. This works great for responding to review comments on unsubmitted changelists.

I also added an "update-or-post" option to allow a single Perforce custom tool (command line) to take care of both,

I doubt this is laid out exactly as you'd prefer, but I wanted to get comments and let people know I'd figured out a way to make this work.
