### PR TITLE
Don't include Error Stream output in the Diff

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -493,12 +493,14 @@ class GitClient(SCMClient):
             diff_lines = execute([self.git, "diff", "--no-color",
                                   "--no-prefix", "--no-ext-diff", "-r", "-u",
                                   rev_range],
-                                 split_lines=True)
+                                 split_lines=True,
+                                 with_errors=False)
             return self.make_svn_diff(ancestor, diff_lines)
         elif self.type == "perforce":
             diff_lines = execute([self.git, "diff", "--no-color",
                                   "--no-prefix", "-r", "-u", rev_range],
-                                 split_lines=True)
+                                 split_lines=True,
+                                 with_errors=False)
             return self.make_perforce_diff(ancestor, diff_lines)
         elif self.type == "git":
             cmdline = [self.git, "diff", "--no-color", "--full-index",
@@ -509,7 +511,7 @@ class GitClient(SCMClient):
                 self.capabilities.has_capability('diffs', 'moved_files')):
                 cmdline.append('-M')
 
-            return execute(cmdline)
+            return execute(cmdline, with_errors=False)
 
         return None
 


### PR DESCRIPTION
We ran into a problem where the diff is generated properly and git doesn't throw an error, but it prints warnings to stderr during the diff generation. The error stream content creates a corrupted diff, which causes breakage on the Review Board server. This patch makes it so that the diffs don't include the stderr stream content.

Sample Warning:
   warning: CRLF will be replaced by LF in pom.xml.
   The file will have its original line endings in your working directory.
