### PR TITLE
Fix handling of repository name in 'rbt status'

### DIFF
--- a/rbtools/commands/status.py
+++ b/rbtools/commands/status.py
@@ -47,7 +47,7 @@ class Status(Command):
             repo_id = get_repository_id(
                 repository_info,
                 api_root,
-                repository_name=self.config.get('REPOSITORY', None))
+                repository_name=self.options.repository_name)
 
             if repo_id:
                 query_args['repository'] = repo_id


### PR DESCRIPTION
rbt status ignores --repository, thus repository matching based on name fails
