### PR TITLE
Output URL of new incomplete review

### DIFF
--- a/rbtools/commands/post.py
+++ b/rbtools/commands/post.py
@@ -547,6 +547,8 @@ class Post(Command):
                     'Your review request still exists, but the diff is '
                     'not attached.\n')
 
+                error_msg.append('%s\n' % review_request.absolute_url)
+
                 raise CommandError('\n'.join(error_msg))
 
         try:


### PR DESCRIPTION
If `rbt post` did create review but failed before completing it,
user had to find the incomplete review themselves (and discard
or complete it manually).

This patch adds the URI to the error message so that remedy is less
cumbersome.
