### PR TITLE
Read System Arguments after .reviewboardrc

### DIFF
--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -391,6 +391,10 @@ class Command(object):
         """
         self.config = load_config()
 
+        # Injected system arguments parameter from .reviewboardrc
+        # Now its time to update argv
+        argv = sys.argv
+
         parser = self.create_parser(self.config, argv)
         parser.add_argument('args', nargs=argparse.REMAINDER)
 


### PR DESCRIPTION
In my repositories I have added functionality to .reviewboardrc to allow for a command prompt menu instead of having a long list of parameters each time you commit.  This worked well with post-review but since we upgraded to rbt post we encountered some issues.  The way it works is we inject systems argument after asking a few basic questions (summary, description, and group of reviewers).  I propose to reload the system arguments after the reviewboardrc allowing more flexibility to what people can add in .reviewboardrc after the file has been read/executed instead of just passing the argv.
