### PR TITLE
Added explicit exception class to except clause

### DIFF
--- a/rbtools/utils/filesystem.py
+++ b/rbtools/utils/filesystem.py
@@ -19,7 +19,7 @@ def cleanup_tempfiles():
     for tmpfile in tempfiles:
         try:
             os.unlink(tmpfile)
-        except:
+        except OSError:
             pass
 
     for tmpdir in tempdirs:


### PR DESCRIPTION
It's generally bad form to have a global, catch-all except clause. Fixed.
