### PR TITLE
Avoid external diff execution when performing a git diff

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -467,7 +467,7 @@ class GitClient(SCMClient):
             diff_cmd_params = ['--no-color', '--no-prefix', '-r', '-u']
         elif self.type == 'git':
             diff_cmd_params = ['--no-color', '--full-index',
-                               '--ignore-submodules']
+                               '--ignore-submodules', '--no-ext-diff']
 
             if (self.capabilities is not None and
                 self.capabilities.has_capability('diffs', 'moved_files')):


### PR DESCRIPTION
If a user has an external diff program set up, rbt will hang with the following example output:

```
$ rbt post --repository-url=git://git.apache.org/mesos.git --tracking-branch=master --review-request-id=25945 --debug d1ae39df5f7e228b1cb5eef60bcb346fa428333e 1eeeef0662fcfec899939a18be86e93705bf2791
>>> RBTools 0.6.2
>>> Python 2.7.6 (default, Mar 22 2014, 22:59:56)
[GCC 4.8.2]
>>> Running on Linux-3.13.0-32-generic-x86_64-with-Ubuntu-14.04-trusty
>>> Home = /home/dhamon
>>> Current directory = /home/dhamon/git/mesos
>>> Checking for a Subversion repository...
>>> Running: svn info git://git.apache.org/mesos.git --non-interactive
>>> Command exited with rc 1: ['svn', 'info', 'git://git.apache.org/mesos.git', '--non-interactive']
svn: warning: W170000: Unrecognized URL scheme for 'git://git.apache.org/mesos.git'

svn: E200009: Could not display info for all targets because some targets don't exist
---
>>> Checking for a Git repository...
>>> Running: git rev-parse --git-dir
>>> Running: git config core.bare
>>> Running: git rev-parse --show-toplevel
>>> Running: git symbolic-ref -q HEAD
>>> Running: git config --get branch.MESOS-1751.dispatch.merge
>>> Command exited with rc 1: ['git', 'config', '--get', 'branch.MESOS-1751.dispatch.merge']
---
>>> Running: git config --get branch.MESOS-1751.dispatch.remote
>>> Command exited with rc 1: ['git', 'config', '--get', 'branch.MESOS-1751.dispatch.remote']
---
>>> Running: git config --get remote.master.url
>>> Command exited with rc 1: ['git', 'config', '--get', 'remote.master.url']
---
>>> repository info: Path: git://git.apache.org/mesos.git, Base path: , Supports changesets: False
>>> Running: git config --get reviewboard.url
>>> Making HTTP GET request to https://reviews.apache.org/api/
>>> Running: git rev-parse d1ae39df5f7e228b1cb5eef60bcb346fa428333e 1eeeef0662fcfec899939a18be86e93705bf2791
>>> Running: git merge-base d1ae39df5f7e228b1cb5eef60bcb346fa428333e master
>>> Running: git diff --no-color --full-index --ignore-submodules d1ae39df5f7e228b1cb5eef60bcb346fa428333e..1eeeef0662fcfec899939a18be86e93705bf2791 -M
```

Running the last command manually launches the external diff program.

Adding '--no-ext-diff' to the command line parameters should fix the issue.
