### PR TITLE
When raising CommandError, include lower-level exception.

### DIFF
--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -681,7 +681,7 @@ class Command(object):
             api_root = api_client.get_root()
         except ServerInterfaceError as e:
             raise CommandError('Could not reach the Review Board '
-                               'server at %s' % server_url)
+                               'server at %s due to %s' % (server_url, e))
         except APIError as e:
             raise CommandError('Unexpected API Error: %s' % e)
 


### PR DESCRIPTION
I recently ran into a problem where under Python 2.7.9, which does SSL certificate validation by default (for the first time in Python history), I was getting weird `Could not reach the Review Board server` errors with no further indication of this being due to a certificate validation failure.
With this change the error would read like this instead: `Could not reach the Review Board server at … due to [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)`