### PR TITLE
Unfinished support for specifying a CA

### DIFF
--- a/rbtools/api/request.py
+++ b/rbtools/api/request.py
@@ -31,6 +31,12 @@ from rbtools import get_package_version
 from rbtools.api.cache import APICache
 from rbtools.api.errors import APIError, create_api_error, ServerInterfaceError
 from rbtools.utils.filesystem import get_home_path
+try:
+    import ssl
+    from six.moves.urllib.request import HTTPSHandler
+except ImportError:
+    ssl = None
+    HTTPSHandler = None
 
 
 RBTOOLS_COOKIE_FILE = '.rbtools-cookies'
@@ -394,7 +400,7 @@ class ReviewBoardServer(object):
     """
     def __init__(self, url, cookie_file=None, username=None, password=None,
                  api_token=None, agent=None, session=None, disable_proxy=False,
-                 auth_callback=None, otp_token_callback=None):
+                 auth_callback=None, otp_token_callback=None, verify=None):
         self.url = url
         if not self.url.endswith('/'):
             self.url += '/'
@@ -448,6 +454,12 @@ class ReviewBoardServer(object):
                                                          password_mgr)
 
         handlers = []
+
+        if verify is not None:
+            assert ssl is not None
+            verify = os.path.expanduser(verify)
+            context = ssl.create_default_context(cafile=verify)
+            handlers.append(HTTPSHandler(context=context))
 
         if disable_proxy:
             handlers.append(ProxyHandler({}))

--- a/rbtools/api/transport/sync.py
+++ b/rbtools/api/transport/sync.py
@@ -21,7 +21,8 @@ class SyncTransport(Transport):
     """
     def __init__(self, url, cookie_file=None, username=None, password=None,
                  api_token=None, agent=None, session=None, disable_proxy=False,
-                 auth_callback=None, otp_token_callback=None, *args, **kwargs):
+                 auth_callback=None, otp_token_callback=None, verify=None,
+                 *args, **kwargs):
         super(SyncTransport, self).__init__(url, *args, **kwargs)
         self.server = ReviewBoardServer(self.url,
                                         cookie_file=cookie_file,
@@ -31,7 +32,8 @@ class SyncTransport(Transport):
                                         session=session,
                                         disable_proxy=disable_proxy,
                                         auth_callback=auth_callback,
-                                        otp_token_callback=otp_token_callback)
+                                        otp_token_callback=otp_token_callback,
+                                        verify=verify)
 
     def get_root(self):
         return self._execute_request(HttpRequest(self.server.url))

--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -216,6 +216,15 @@ class Command(object):
                    help='The API token to use for authentication, instead of '
                         'using a username and password.',
                    added_in='0.7'),
+            Option('--verify',
+                   dest='verify',
+                   metavar='CA',
+                   config_key='SSL_VERIFY',
+                   default=None,
+                   help='The SSL Certificate authority to use for SSL '
+                        'connections',
+                   # TODO: Fill in added_in
+                   added_in='0.7'),
         ]
     )
 
@@ -667,7 +676,8 @@ class Command(object):
                         api_token=self.options.api_token,
                         auth_callback=self.credentials_prompt,
                         otp_token_callback=self.otp_token_prompt,
-                        disable_proxy=not self.options.enable_proxy)
+                        disable_proxy=not self.options.enable_proxy,
+                        verify=self.options.verify)
 
     def get_api(self, server_url):
         """Returns an RBClient instance and the associated root resource.


### PR DESCRIPTION
### This is a VERY FIRST draft and _not_ ready to be merged into master.

Python 2.7.9 is out and enforces SSL certificates in urllib2.urlopen and it's kin. This commit starts to add a `--verify` flag that could be a certificate authority file to be passed to HTTPSContext.

This code is not ready for being merged because a lot of these things are >2.7.9 only and i honestly have no idea how to implement this stuff for older versions of python. I figured I'd post my code as a starting point in case it helps someone actually implement the real deal