### PR TITLE
SubGit support

### DIFF
--- a/rbtools/api/request.py
+++ b/rbtools/api/request.py
@@ -442,7 +442,7 @@ class ReviewBoardServer(object):
         """Reset the user information"""
         self.preset_auth_handler.reset(username, password)
 
-    def process_error(self, http_status, data):
+    def _process_error(self, request_body, http_status, data):
         """Processes an error, raising an APIError with the information."""
         try:
             rsp = json_loads(data)
@@ -467,6 +467,8 @@ class ReviewBoardServer(object):
         """
         try:
             content_type, body = request.encode_multipart_formdata()
+            logging.debug('Request data: %r' % body)
+
             headers = request.headers
 
             if body:
@@ -481,7 +483,7 @@ class ReviewBoardServer(object):
                         request.method)
             rsp = urllib2.urlopen(r)
         except urllib2.HTTPError, e:
-            self.process_error(e.code, e.read())
+            self._process_error(body, e.code, e.read())
         except urllib2.URLError, e:
             raise ServerInterfaceError("%s" % e.reason)
 

--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -378,9 +378,9 @@ class GitClient(SCMClient):
 
         remote_cmd = "git config -f %s/subgit/config --get svn.url" % path
         if server:
-            svn_remote_url = execute(['ssh', 'git', server, remote_cmd])
+            svn_remote_url = execute(['ssh', 'git', server, remote_cmd], ignore_errors=True)
         else:
-            svn_remote_url = execute(remote_cmd.split())
+            svn_remote_url = execute(remote_cmd.split(), ignore_errors=True)
         if not svn_remote_url:
             logging.debug("Failed to retrieve SVN url from remote Subgit configuration")
             return None

--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -418,7 +418,7 @@ class GitClient(SCMClient):
 
         svn_branch = self._get_subgit_tracking_branch('HEAD')
         if svn_branch:
-            git_branch = execute(['git', 'branch'])
+            git_branch = self.get_current_branch()
         else:
             if (hasattr(self.options, 'parent_branch') and
                     self.options.parent_branch is not None):

--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -356,14 +356,16 @@ class GitClient(SCMClient):
                 break
         if server is None:
             logging.debug("Failed to parse git remote URL")
-            return None
+            return None, None
         logging.debug("Got git remote server,path: %s,%s" % (server, path))
         return server, path
 
     @memoize
     def _get_subgit_svn_url(self):
         server, path = self._get_git_remote_server_info()
-        
+        if server is None:
+            return None
+
         remote_cmd = "git config -f %s/subgit/config --get svn.url" % path
         svn_remote_url = execute(['ssh', server, remote_cmd])
         if not svn_remote_url:

--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -233,7 +233,7 @@ class GitClient(SCMClient):
                                   supports_parent_diffs=True)
 
         return None
-        
+
     def _get_git_remote_tracking_info(self):
         upstream_branch = ''
         if self.head_ref:
@@ -271,10 +271,10 @@ class GitClient(SCMClient):
 
                 # There is no remote, so skip this part of upstream_branch.
                 upstream_branch = upstream_branch.split('/')[-1]
-                
+
         return upstream_branch, url
 
-        
+
     def _get_git_svn_info(self):
         data = execute([self.git, "svn", "rebase", "-n"],
                         ignore_errors=True)
@@ -290,7 +290,7 @@ class GitClient(SCMClient):
 
         svn_info = execute([self.git, "svn", "info"], ignore_errors=True)
         return self._parse_svn_info(svn_info, upstream_branch)
-    
+
     def _parse_svn_info(self, svn_info, upstream_branch):
         m = re.search(r'^Repository Root: (.+)$', svn_info, re.M)
         if m:
@@ -308,7 +308,7 @@ class GitClient(SCMClient):
                     else:
                         # already discovered from git-svn or subgit info
                         self.upstream_branch = upstream_branch
-                        
+
                     return SVNRepositoryInfo(path=path,
                                              base_path=base_path,
                                              uuid=uuid,
@@ -332,15 +332,18 @@ class GitClient(SCMClient):
                                           (1, 5, 4))):
                 die("Your installation of git-svn must be upgraded to "
                     "version 1.5.4 or later")
-        
+
         return None
 
     def _is_subgit_configured(self):
         svn_remote_url = self._get_subgit_svn_url()
         return (svn_remote_url is not None)
-        
+
     def _get_git_remote_server_info(self):
-        git_url = execute([self.git, "config", "--get", "remote.origin.url"])
+        git_url = execute([self.git, "config", "--get", "remote.origin.url"],
+                          ignore_errors=True)
+        if git_url is None:
+            return None, None
         git_url = git_url.strip()
         ssh_url_regexes = [
             '(?:git\+)?ssh://([A-Za-z0-9@:.]+?)(/.+)', # ssh://host.com/path/to/repo
@@ -381,7 +384,7 @@ class GitClient(SCMClient):
         svn_remote = self._get_subgit_svn_url()
         server, path = self._get_git_remote_server_info()
         svn_info = execute(["svn", "info", svn_remote])
-        
+
         upstream_branch, url = self._get_git_remote_tracking_info()
         return self._parse_svn_info(svn_info, upstream_branch)
 

--- a/rbtools/clients/tests.py
+++ b/rbtools/clients/tests.py
@@ -826,6 +826,25 @@ class SvnWrapperMixin(object):
             if not self.is_exe_in_path(exe):
                 raise SkipTest('missing svn stuff!  giving up!')
 
+        if not self._tmpbase:
+            self._tmpbase = self.create_tmp_dir()
+
+        self._create_svn_repo()
+        self._fire_up_svnserve()
+        self._fill_in_svn_repo()
+
+        try:
+            self._get_testing_clone()
+        except (OSError, IOError):
+            msg = 'could not clone from svn repo!  skipping...'
+            raise SkipTest(msg), None, sys.exc_info()[2]
+
+        self._spin_up_client()
+        self._stub_in_config_and_options()
+
+    def tearDown(self):
+        os.kill(self._svnserve_pid, 9)
+
     def _svn_add_file_commit(self, filename, data, msg, add_file=True):
         outfile = open(filename, 'w')
         outfile.write(data)
@@ -970,7 +989,7 @@ class MercurialSubversionClientTests(MercurialTestBase, SvnWrapperMixin):
         SvnWrapperMixin.__init__(self)
 
     def setUp(self):
-        super(MercurialSubversionClientTests, self).setUp()
+        MercurialTestBase.setUp(self)
         self._hg_env = {'FOO': 'BAR'}
 
         # Make sure hgsubversion is enabled.
@@ -989,32 +1008,13 @@ class MercurialSubversionClientTests(MercurialTestBase, SvnWrapperMixin):
             raise SkipTest('unable to use `hgsubversion` extension!  '
                            'giving up!')
 
-        if not self._tmpbase:
-            self._tmpbase = self.create_tmp_dir()
-
-        self._create_svn_repo()
-        self._fire_up_svnserve()
-        self._fill_in_svn_repo()
-
-        try:
-            self._get_testing_clone()
-        except (OSError, IOError):
-            msg = 'could not clone from svn repo!  skipping...'
-            raise SkipTest(msg), None, sys.exc_info()[2]
-
-        self._spin_up_client()
-        self._stub_in_config_and_options()
+        SvnWrapperMixin.setUp(self)
 
     def _has_hgsubversion(self):
         output = self._run_hg(['svn', '--help'],
                               ignore_errors=True, extra_ignore_errors=(255))
 
         return not re.search("unknown command ['\"]svn['\"]", output, re.I)
-
-    def tearDown(self):
-        super(MercurialSubversionClientTests, self).tearDown()
-
-        os.kill(self._svnserve_pid, 9)
 
     def _get_testing_clone(self):
         self.clone_dir = os.path.join(self._tmpbase, 'checkout.hg')


### PR DESCRIPTION
RBTools currently supports interacting with reviews from a git-svn clone; it jumps through some hoops specific to git-svn to make everything happy from the perspective of the ReviewBoard API and backend SVN repo. However, it has no such support for [SubGit][subgit], which is (IMHO) a far superior translation tool. This PR aims to provide that support, so that "rbt post" and other operations Just Work&#8482; when the local git repo is a clone of a SubGit mirror.

Assuming that you have a setup like this:
```shell
[subgit-server] $ subgit configure --svn-url svn+ssh://svn.example.com/path/to/repo ./repo.git
[subgit-server] $ $EDITOR repo.git/subgit/config repo.git/subgit/authors.txt
[subgit-server] $ subgit install ./repo.git

[some-client] $ git clone ssh://subgit-server.example.com/repo.git
```
the following commands should work:
```shell
[some-client] $ cd repo.git
[some-client] $ gco feature/awesome
[some-client] $ rbt diff
[some-client] $ rbt post
[some-client] $ gco feature/depends_on_awesome
[some-client] $ rbt post --parent feature/awesome
```
and possibly others, but that is most of my workflow (besides adding backend-agnostic options to the above commands, such as --diff-only or --change-description, etc).

This PR is currently mostly for discussion value, as there are some significant known limitations:
1) No tests (yet). 
   - There were also no tests for git-svn when I started
   - I plan to run my new (forthcoming) tests against both kinds of translation

2) Requires SSH access to the SubGit mirror host.
   - RBTools must inspect the SubGit configuration to determine the SVN URL.
   - There's a git config option you can set to specify it explicitly, but this is not currently documented, and it should probably be a .reviewboardrc option instead.

3) It's obviously way behind master. I will rebase and re-verify once I have a bunch of tests.

Also inviting the SubGit folks to participate in this discussion.

[subgit]: http://www.subgit.com/