### PR TITLE
Ignore UnicodeDecodeError

### DIFF
--- a/rbtools/utils/process.py
+++ b/rbtools/utils/process.py
@@ -98,14 +98,14 @@ def execute(command,
 
         if split_lines and len(output) > 0:
             if results_unicode and isinstance(output[0], six.binary_type):
-                return [line.decode(encoding) for line in output]
+                return [line.decode(encoding, 'replace') for line in output]
             elif not results_unicode and isinstance(output[0], six.text_type):
-                return [line.encode('utf-8') for line in output]
+                return [line.encode('utf-8', 'replace') for line in output]
         elif not split_lines:
             if results_unicode and isinstance(output, six.binary_type):
-                return output.decode(encoding)
+                return output.decode(encoding, 'replace')
             elif not results_unicode and isinstance(output, six.text_type):
-                return output.encode('utf-8')
+                return output.encode('utf-8', 'replace')
 
         return output
 


### PR DESCRIPTION
In some cases, the decoding error occurred.
```py
Traceback (most recent call last):
  File "/usr/local/bin/rbt", line 9, in <module>
    load_entry_point('RBTools==0.7.2', 'console_scripts', 'rbt')()
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/commands/main.py", line 133, in main
    command.run_from_argv([RB_MAIN, command_name] + args)
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/commands/__init__.py", line 555, in run_from_argv
    exit_code = self.main(*args) or 0
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/commands/diff.py", line 68, in main
    extra_args=extra_args)
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/clients/svn.py", line 319, in diff
    diff = self._run_svn(diff_cmd, split_lines=True)
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/clients/svn.py", line 707, in _run_svn
    return execute(cmdline, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/RBTools-0.7.2-py2.7.egg/rbtools/utils/process.py", line 104, in execute
    data = [line.decode('utf-8') for line in data]
  File "/usr/local/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xc2 in position 30: invalid continuation byte
```