### PR TITLE
get_server_url throws an AttributeError on rbt login/logout

### DIFF
--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -721,8 +721,10 @@ class Command(object):
         """Returns the Review Board server url."""
         if self.options.server:
             server_url = self.options.server
-        else:
+        elif tool:
             server_url = tool.scan_for_server(repository_info)
+        else:
+            server_url = None
 
         if not server_url:
             print('Unable to find a Review Board server for this source code '


### PR DESCRIPTION
If you execute `rbt login` or `rbt logout` with nothing in self.options.server then the command will fail with an AttributeError:

   CRITICAL:'NoneType' object has no attribute 'scan_for_server'

rather than showing the friendly error message.