### PR TITLE
fix help arg search range

### DIFF
--- a/rbtools/commands/main.py
+++ b/rbtools/commands/main.py
@@ -96,8 +96,8 @@ def main():
     args = opt.command[1:]
 
     if command_name == 'help':
-        help(args, parser)
-    elif opt.help or '--help' in args[:2] or '-h' in args[2]:
+        help(args, parser):2
+    elif opt.help or '--help' in args[:2] or '-h' in args[:2]:
         help(opt.command, parser)
 
     ep = find_entry_point_for_command(command_name)

--- a/rbtools/commands/main.py
+++ b/rbtools/commands/main.py
@@ -96,7 +96,7 @@ def main():
     args = opt.command[1:]
 
     if command_name == 'help':
-        help(args, parser):2
+        help(args, parser):
     elif opt.help or '--help' in args[:2] or '-h' in args[:2]:
         help(opt.command, parser)
 

--- a/rbtools/commands/main.py
+++ b/rbtools/commands/main.py
@@ -96,7 +96,7 @@ def main():
     args = opt.command[1:]
 
     if command_name == 'help':
-        help(args, parser):
+        help(args, parser)
     elif opt.help or '--help' in args[:2] or '-h' in args[:2]:
         help(opt.command, parser)
 

--- a/rbtools/commands/main.py
+++ b/rbtools/commands/main.py
@@ -97,7 +97,7 @@ def main():
 
     if command_name == 'help':
         help(args, parser)
-    elif opt.help or '--help' in args or '-h' in args:
+    elif opt.help or '--help' in args[:2] or '-h' in args[2]:
         help(opt.command, parser)
 
     ep = find_entry_point_for_command(command_name)


### PR DESCRIPTION
if args include Chinese warning will show

```
/Library/Python/2.7/site-packages/RBTools-0.8a0.dev0-py2.7.egg/rbtools/c
ommands/main.py:101: UnicodeWarning: Unicode equal comparison failed to
convert both arguments to Unicode - interpreting them as being unequal
  elif opt.help or '--help' in args or '-h' in args:
```