### PR TITLE
fix 'ascii' codec can't decode byte 0xef in position 583: ordinal not…

### DIFF
--- a/rbtools/utils/process.py
+++ b/rbtools/utils/process.py
@@ -4,6 +4,9 @@ import logging
 import os
 import subprocess
 import sys
+if sys.platform.startswith('linux'):
+  reload(sys)
+  sys.setdefaultencoding("utf-8")
 
 import six
 


### PR DESCRIPTION
… in range(128)

we had multiple errors like: 
Unicodedecodeerror ascii codec can t decode byte 0xe3 in position 0 ordinal not in range 128 
or
CRITICAL: 'ascii' codec can't decode byte 0xef in position 583: ordinal not in range(128) 
setting utf-8 as default fixed the failure