### PR TITLE
'/' is valid client root for perfroce, adding support for the same.

### DIFF
--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -231,6 +231,7 @@ class PerforceClient(SCMClient):
 
         client_root = p4_info.get('Client root')
 
+
         if client_root is None:
             return None
 
@@ -238,10 +239,8 @@ class PerforceClient(SCMClient):
         # client, so don't enforce the repository directory check.
         if (client_root.lower() != 'null' or
             not sys.platform.startswith('win')):
-            norm_cwd = os.path.normcase(os.path.realpath(os.getcwd()) +
-                                        os.path.sep)
-            norm_client_root = os.path.normcase(os.path.realpath(client_root) +
-                                                os.path.sep)
+            norm_cwd = os.path.normcase(os.path.realpath(os.getcwd())) 
+            norm_client_root = os.path.normcase(os.path.realpath(client_root))
 
             # Don't accept the repository if the current directory
             # is outside the root of the Perforce client.

--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -231,7 +231,6 @@ class PerforceClient(SCMClient):
 
         client_root = p4_info.get('Client root')
 
-
         if client_root is None:
             return None
 

--- a/rbtools/clients/tests.py
+++ b/rbtools/clients/tests.py
@@ -2010,7 +2010,7 @@ class PerforceClientTests(SCMClientTests):
 
             def info(self):
                 return {
-                    'Client root': '/',
+                    'Client root': os.getcwd() + os.path.sep + 'invalid',
                     'Server address': SERVER_PATH,
                     'Server version': 'P4D/FREEBSD60X86_64/2012.2/525804 '
                                       '(2012/09/18)',


### PR DESCRIPTION
Issue: In case the perforce client root is /, then norm_client_root becomes // and then condition 'if not norm_cwd.startswith(norm_client_root):' becomes false, which is not correct. Solution is not to add separators at the end for both norm_cwd and norm_client_root.