### PR TITLE
Git for Windows Bash Shell issue

### DIFF
--- a/rbtools/utils/users.py
+++ b/rbtools/utils/users.py
@@ -38,7 +38,7 @@ def get_authenticated_session(api_client, api_root, auth_required=False,
                 logging.error('Check that you are not running this script '
                               'from a Cygwin terminal emulator (or use '
                               'Cygwin Python to run it). '
-                              'You may also try logining in first with '
+                              'You may also try logging in first with '
                               'rbt login --username <username> --password <password> '
                               'or rbt login --api-token')
             raise CommandError('Unable to log in to Review Board.')

--- a/rbtools/utils/users.py
+++ b/rbtools/utils/users.py
@@ -35,10 +35,12 @@ def get_authenticated_session(api_client, api_root, auth_required=False,
         if not sys.stdin.isatty():
             logging.error('Authentication is required but input is not a tty.')
             if sys.platform == 'win32':
-                logging.info('Check that you are not running this script '
-                             'from a Cygwin terminal emulator (or use '
-                             'Cygwin Python to run it).')
-
+                logging.error('Check that you are not running this script '
+                              'from a Cygwin terminal emulator (or use '
+                              'Cygwin Python to run it). '
+                              'You may also try logining in first with '
+                              'rbt login --username <username> --password <password> '
+                              'or rbt login --api-token')
             raise CommandError('Unable to log in to Review Board.')
 
         logging.info('Please log in to the Review Board server at %s',


### PR DESCRIPTION
When trying to use rtb to post changes from within a Git for Windows Bash shell I was getting this error
"Authentication is required but input is not a tty
Check that you are not running this script from a Cygwin terminal emulator (or use Cygwin Python to run it)."

It wasn't clear that you could login with alternative methods and then rbt could work normally. I think these changes to the error message might help people figure out how to work with rbt inside the Git for Windows bash shell.