### PR TITLE
Ticket-4551: add --no-renames option to 'rbt diff' for GIT repo

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -517,7 +517,8 @@ class GitClient(SCMClient):
                 git_cmd.extend(['-c', 'diff.noprefix=false'])
 
             if (self.capabilities is not None and
-                self.capabilities.has_capability('diffs', 'moved_files')):
+                self.capabilities.has_capability('diffs', 'moved_files') and
+                not self.options.no_renames):
                 diff_cmd_params.append('-M')
             else:
                 diff_cmd_params.append('--no-renames')

--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -524,6 +524,21 @@ class Command(object):
         ]
     )
 
+    git_options = OptionGroup(
+        name='GIT Options',
+        description='Git-specific options for controlling diff '
+                    'generation.',
+        option_list=[
+            Option('--no-renames',
+                   dest='no_renames',
+                   action='store_true',
+                   default=False,
+                   help='Turn off rename detection, '
+                        'even when the configuration file '
+                        'sgives the default to do so.'),
+        ]
+    )
+
     def __init__(self):
         self.log = logging.getLogger('rb.%s' % self.name)
 

--- a/rbtools/commands/diff.py
+++ b/rbtools/commands/diff.py
@@ -17,6 +17,7 @@ class Diff(Command):
         Command.perforce_options,
         Command.subversion_options,
         Command.tfs_options,
+        Command.git_options,
     ]
 
     def main(self, *args):


### PR DESCRIPTION
https://hellosplat.com/s/beanbag/tickets/4551/

Adding --no-renames option to 'rbt diff' for GIT repo