### PR TITLE
add `--parent-diff-filename` for `rbt post`

### DIFF
--- a/docs/rbtools/rbt/commands/post.rst
+++ b/docs/rbtools/rbt/commands/post.rst
@@ -299,6 +299,13 @@ You can also use the special value of ``-`` to pipe a diff into STDIN::
 Using STDIN will require either a valid cookie, or the :option:`--username`
 and :option:`--password` options.
 
+If your diff depends on some other changes that are not yet in the
+repository, you can specify a "parent diff" (usually the diff between
+what's in the repository and whatever your pre-existing diff is based on)::
+
+    $ rbt post --diff-filename=mycode.diff --parent-diff-filename=parent.diff
+
+You cannot use the ``-`` special value here.
 
 .. _guessing-fields:
 

--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -395,6 +395,11 @@ class Command(object):
                    metavar='FILENAME',
                    help='Uploads an existing diff file, instead of '
                         'generating a new diff.'),
+            Option('--parent-diff-filename',
+                   dest='parent_diff_filename',
+                   default=None,
+                   metavar='FILENAME',
+                   help='Use this diff as parent of the --diff-filename.'),
         ]
     )
 

--- a/rbtools/commands/post.py
+++ b/rbtools/commands/post.py
@@ -784,6 +784,15 @@ class Post(Command):
                         diff = fp.read()
                 except IOError as e:
                     raise CommandError('Unable to open diff filename: %s' % e)
+
+            if self.options.parent_diff_filename:
+                try:
+                    diff_path = os.path.join(origcwd,
+                                             self.options.parent_diff_filename)
+                    with open(diff_path, 'rb') as fp:
+                        parent_diff = fp.read()
+                except IOError as e:
+                    raise CommandError('Unable to open parent diff filename: %s' % e)
         else:
             self.revisions = get_revisions(self.tool, self.cmd_args)
 


### PR DESCRIPTION
All the logic is already there, only the command line option was missing. This helps (for example) with submitting a review for changes that depend on another review that hasn't been committed yet, which is sadly common in environments that don't use branches (ugh).