### PR TITLE
Remove warnings in python 3

### DIFF
--- a/rbtools/commands/__init__.py
+++ b/rbtools/commands/__init__.py
@@ -9,6 +9,7 @@ import sys
 
 import colorama
 import pkg_resources
+import six
 from six.moves.urllib.parse import urlparse
 
 from rbtools import get_version_string
@@ -696,7 +697,10 @@ class Command(object):
         args = self.options.args
 
         # Check that the proper number of arguments have been provided.
-        argspec = inspect.getargspec(self.main)
+        if six.PY3:
+            argspec = inspect.getfullargspec(self.main)
+        else:
+            argspec = inspect.getargspec(self.main)
         minargs = len(argspec[0]) - 1
         maxargs = minargs
 

--- a/rbtools/utils/checks.py
+++ b/rbtools/utils/checks.py
@@ -18,10 +18,14 @@ def check_install(command):
     instance, 'svn help' or 'git --version').
     """
     try:
-        subprocess.Popen(command,
+        p = subprocess.Popen(command,
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
+        p.wait()
+        p.stderr.close()
+        p.stdin.close()
+        p.stdout.close()
         return True
     except (OSError, ValueError):
         # We catch ValueError exceptions here to work around bug in the


### PR DESCRIPTION
This fixes warnings in python 3.7 when run with PYTHONWARNINGS=default