### PR TITLE
Fix rbt on Python 3.5 (invalid string handling)

### DIFF
--- a/rbtools/api/decode.py
+++ b/rbtools/api/decode.py
@@ -26,6 +26,12 @@ DEFAULT_DECODER = DefaultDecoder
 
 
 def JsonDecoder(payload):
+    # In Python 3, the payload can be bytes, not str
+    # and json.loads explicitly requires decoded strings
+    try:
+        payload = payload.decode('utf-8')
+    except AttributeError:  # Already a string
+        pass
     return json.loads(payload)
 
 

--- a/rbtools/api/request.py
+++ b/rbtools/api/request.py
@@ -564,6 +564,13 @@ class ReviewBoardServer(object):
 
     def process_error(self, http_status, data):
         """Processes an error, raising an APIError with the information."""
+        # In Python 3, the data can be bytes, not str
+        # and json.loads explicitly requires decoded strings
+        try:
+            data = data.decode('utf-8')
+        except AttributeError:  # Already a string
+            pass
+
         try:
             rsp = json_loads(data)
 

--- a/rbtools/utils/process.py
+++ b/rbtools/utils/process.py
@@ -130,9 +130,9 @@ def execute(command,
     popen_encoding_args = {}
 
     if results_unicode:
-        # Popen on Python 2 doesn't support the ``encoding`` parameter, so we
-        # have to use ``universal_newlines`` and then decode later.
-        if six.PY3:
+        # Popen before Python 3.6 doesn't support the ``encoding`` parameter,
+        # so we have to use ``universal_newlines`` and then decode later.
+        if six.PY3 and sys.version_info.minor >= 6:
             popen_encoding_args['encoding'] = 'utf-8'
         else:
             popen_encoding_args['universal_newlines'] = True


### PR DESCRIPTION
Popen didn't [gain the `encoding` parameter until 3.6](https://docs.python.org/3/whatsnew/3.6.html#subprocess).

On 3.5, [`universal_newlines` is available, but `encoding` is not](https://docs.python.org/3.5/library/subprocess.html).

With these changes, `rbt-log-post` works in a Python 3.5.6 environment. Similarly, the test suite passes for me (save 3 svn-related tests that are failing due to not have subversion installed).

I'd be happy to add some new tests if desired, but this also seems small enough in scope that it should be safe as-is.