### PR TITLE
Fix crash with german date format

### DIFF
--- a/rbtools/clients/svn.py
+++ b/rbtools/clients/svn.py
@@ -891,7 +891,7 @@ class SVNClient(SCMClient):
                 svninfo = {}
 
                 for info in result:
-                    parts = info.strip().split(': ', 1)
+                    parts = info.strip().decode('ascii', errors='replace').split(': ', 1)
 
                     if len(parts) == 2:
                         key, value = parts


### PR DESCRIPTION
Error was:

    > rbt post --debug mychangelist
    [...]
    >>> Running: svn --non-interactive info ...
        Traceback (most recent call last):
    File "C:\Program Files (x86)\RBTools\bin\..\Python27\Scripts\rbt-script.py", line 11, in <module>
        load_entry_point('RBTools==1.0.1', 'console_scripts', 'rbt')()
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\commands\main.py", line 120, in main
        command.run_from_argv([RB_MAIN, command_name] + args)
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\commands\__init__.py", line 719, in run_from_argv
        exit_code = self.main(*args) or 0
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\commands\post.py", line 806, in main
        extra_args=extra_args)
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\clients\svn.py", line 520, in diff
        diff = self.convert_to_absolute_paths(diff, repository_info)
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\clients\svn.py", line 845, in convert_to_absolute_paths
        info = self.svn_info(file, True)
    File "C:\Program Files (x86)\RBTools\Python27\lib\site-packages\rbtools-1.0.1-py2.7.egg\rbtools\clients\svn.py", line 894, in svn_info
        parts = info.strip().split(': ', 1)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 55: ordinal not in range(128)

I am running a Windows with german date format, so the line in question was `Last Changed Date: 2019-03-27 09:53:56 +0100 (Mi., 27 Mär 2019)` (notice the `ä` in the Month name).