### PR TITLE
ensure utf-8 ncoding when processing commit message

### DIFF
--- a/rbtools/clients/__init__.py
+++ b/rbtools/clients/__init__.py
@@ -509,7 +509,7 @@ class SCMClient(object):
         # Try to pull the body of the commit out of the full commit
         # description, so that we can skip the summary.
         if len(lines) >= 3 and lines[0] and not lines[1]:
-            result['description'] = '\n'.join(lines[2:]).strip()
+            result['description'] = '\n'.join(x.decode('utf-8') for x in lines[2:]).strip()
         else:
             result['description'] = commit_message
 


### PR DESCRIPTION
The `rbt port` command fails to post review  with error

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 57: ordinal not in range(128)

When commit message has a unicode char, for example:
TlsOverhead.callOpNull       true  thrpt   25  12865.357 ± 135.963  ops/s