### PR TITLE
Fix setup-repo not finding the repository

### DIFF
--- a/rbtools/commands/setup_repo.py
+++ b/rbtools/commands/setup_repo.py
@@ -47,9 +47,8 @@ class SetupRepo(Command):
         """
         # Go through each matching repo and prompt for a selection. If a
         # selection is made, immediately return the selected repo.
+        repo_paths = {}
         for repository_page in api_root.get_repositories().all_pages:
-            repo_paths = {}
-
             for repository in repository_page:
                 if repository.tool != tool_name:
                     continue
@@ -59,17 +58,17 @@ class SetupRepo(Command):
                 if 'mirror_path' in repository:
                     repo_paths[repository['mirror_path']] = repository
 
-            closest_path = difflib.get_close_matches(repository_info.path,
-                                                     six.iterkeys(repo_paths),
-                                                     n=4, cutoff=0.4)
+        closest_path = difflib.get_close_matches(repository_info.path,
+                                                 six.iterkeys(repo_paths),
+                                                 n=4, cutoff=0.4)
 
-            for path in closest_path:
-                repo = repo_paths[path]
-                question = ('Use the %s repository "%s" (%s)?'
-                            % (tool_name, repo['name'], repo['path']))
+        for path in closest_path:
+            repo = repo_paths[path]
+            question = ('Use the %s repository "%s" (%s)?'
+                        % (tool_name, repo['name'], repo['path']))
 
-                if confirm(question):
-                    return repo
+            if confirm(question):
+                return repo
 
         return None
 


### PR DESCRIPTION
The issue is that setup-repo retrives repositories in pages
After each page retrieved rbt checks if any of the repositories
matching current and if not asks user question about inexact
matches if exact match not found, and this create problem when
exact match will be on subsequent page

Resolution to the problem is to retrieve complete repository list
1st and after that look for match to the current path, this way
exact match will be found regardless which page it's on