### PR TITLE
Fix for change in re.split behaviour in python 3.7

### DIFF
--- a/rbtools/clients/svn.py
+++ b/rbtools/clients/svn.py
@@ -1421,7 +1421,7 @@ class SVNRepositoryInfo(RepositoryInfo):
     def _split_on_slash(self, path):
         # Split on slashes, but ignore multiple slashes and throw away any
         # trailing slashes.
-        split = re.split('/*', path)
+        split = re.split('/+', path)
         if split[-1] == '':
             split = split[0:-1]
         return split


### PR DESCRIPTION
I think this is a side effect of the change to split on patterns that match empty strings described here: https://docs.python.org/3.7/whatsnew/3.7.html#re

rbtools is not the only project to get bit by this. e.g.: https://github.com/PyTables/PyTables/pull/687