### PR TITLE
Fix Perforce client errors when run by Python 3

### DIFF
--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -340,7 +340,7 @@ class P4Wrapper(object):
 
             return result
         elif input_string is not None:
-            if not isinstance(bytes, input_string):
+            if not isinstance(input_string, bytes):
                 input_string = input_string.encode('utf8')
 
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE)

--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -273,12 +273,6 @@ class P4Wrapper(object):
         """
         cmd = ['p4']
 
-        if input_string:
-            try:
-                input_string = input_string.encode('utf8')
-            except (UnicodeEncodeError, AttributeError):
-                pass
-            
         if marshalled:
             cmd += ['-G']
 
@@ -346,6 +340,9 @@ class P4Wrapper(object):
 
             return result
         elif input_string is not None:
+            if not isinstance(bytes, input_string):
+                input_string = input_string.encode('utf8')
+
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             p.communicate(input_string)  # Send input, wait, set returncode
 


### PR DESCRIPTION
In Python 3, the string must be encoded to bytes before being passed into `p4`. 