### PR TITLE
Fix an encoding error where revision svn is expected as bytes, not str.

### DIFF
--- a/rbtools/clients/git.py
+++ b/rbtools/clients/git.py
@@ -888,7 +888,7 @@ class GitClient(SCMClient):
             bytes:
             The reformatted diff contents.
         """
-        rev = self._execute([self.git, 'svn', 'find-rev', merge_base]).strip()
+        rev = self._execute([self.git, 'svn', 'find-rev', merge_base], results_unicode=False).strip()
 
         if not rev:
             return None


### PR DESCRIPTION
This fixes an error that occurs when I attempt to do `rbt post` from a git+svn workspace, from my Win10 PC running Git Bash.

The fix as authored appears to be the correct behavior. The code clearly expects `rev` to be a bytes value, not a string. The fact that `execute()` is apparently returning bytes results for anyone when `results_unicode=True` (I have reports it works for most people) seems like an error in `execute()` that should probably be investigated separately. 

### OS information:

```
Edition	Windows 10 Pro
Version	20H2
Installed on	‎11/‎24/‎2020
OS build	19042.630
Experience	Windows Feature Experience Pack 120.2212.31.0

$ bash --version
GNU bash, version 4.4.23(1)-release (x86_64-pc-msys)

$ git --version
git version 2.29.2.windows.2

$ python --version
Python 3.6.8
```

### The backtrace of the crash which this change fixes:
 ```
Traceback (most recent call last):
  File "C:\Python36\Scripts\rbt-script.py", line 11, in <module>
    load_entry_point('RBTools==2.0.1a0.dev0', 'console_scripts', 'rbt')()
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\commands\main.py", line 124, in main
    command.run_from_argv([RB_MAIN, command_name] + args)
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\commands\__init__.py", line 770, in run_from_argv
    exit_code = self.main(*args) or 0
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\commands\post.py", line 1059, in main
    extra_args)
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\commands\post.py", line 1345, in _get_squashed_diff
    **diff_kwargs)
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\clients\git.py", line 706, in diff
    find_renames_threshold=git_find_renames_threshold)
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\clients\git.py", line 865, in make_diff
    return self.make_svn_diff(merge_base, diff_lines)
  File "C:\Python36\lib\site-packages\rbtools-2.0.1a0.dev0-py3.6.egg\rbtools\clients\git.py", line 921, in make_svn_diff
    diff_data += b'--- %s\t(revision %s)\n' % (original_file, rev)
TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'
```
