### PR TITLE
rbtools should declare setuptools as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         'six>=1.8.0',
         'texttable',
         'tqdm',
+        'setuptools',
     ],
     packages=find_packages(exclude=['tests']),
     include_package_data=True,


### PR DESCRIPTION
rbtools uses pkg_resources which is provided by setuptools. Since this dependency isn't declared, my builds fail due to "ModuleNotFoundError: No module named 'pkg_resources'"