### PR TITLE
Fix python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ setup(
     download_url=('https://downloads.reviewboard.org/releases/%s/%s.%s/'
                   % (PACKAGE_NAME, VERSION[0], VERSION[1])),
     python_requires=(
-        '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*'
+        '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, '
         '!=3.5.*'
     ),
     classifiers=[


### PR DESCRIPTION
It was missing a comma.

---

At first I saw that issues were disabled, so I read the README and went to the splat (or something) website to register. GitHub login didn't work so I created an account.

In the meantime I've seen in another PR that you don't take PRs here, and you mentioned reviewboard, which seems to be an updated version of the splat website mentioned above. I created an account again, giving personal info and clicking on the Google captcha. I tried to submit a report, but couldn't find how to do so using the web interface. That's way too much effort for a one-character diff, so I'll let you apply this change (if you're interesting in applying it) in the right place 🙂 

If you could delete the accounts using the username `pawamoy` on the splat and reviewboard websites, that would be appreciated.