### PR TITLE
Fix iterating over paginated resource

### DIFF
--- a/rbtools/api/resource.py
+++ b/rbtools/api/resource.py
@@ -1028,6 +1028,7 @@ class ListResource(Resource):
 
             try:
                 page = page.get_next()
+                yield page
             except StopIteration:
                 break
 


### PR DESCRIPTION
The `all_pages` generator should yield pages starting from itself  and while pages have the `<next>link</next>` inside `<pages>` tag.