### PR TITLE
Added code to handle sos branch being a string as opposed to just an int

### DIFF
--- a/rbtools/clients/sos.py
+++ b/rbtools/clients/sos.py
@@ -785,7 +785,7 @@ class SOSClient(BaseSCMClient):
             self._get_wa_root() or
             os.getcwd()
         )
-
+       # print(f"SUBCOMMAND is {subcommand} and args {args}")
         return execute(['soscmd', subcommand] + list(args),
                        cwd=cwd,
                        **kwargs)
@@ -1711,11 +1711,11 @@ class SOSClient(BaseSCMClient):
                 # For unmanaged (generally new) files, we want to diff against
                 # an empty temp file. We'll export if it's anything but new.
                 if orig_revision != SOSObjectRevision.UNMANAGED:
-                    assert isinstance(orig_revision, int)
+                  #  assert isinstance(orig_revision, int)
 
                     os.unlink(tmp_orig_filename)
                     self.run_soscmd('exportrev',
-                                    '%s/#/%d' % (filename, orig_revision),
+                                    '%s/#/%s' % (filename, str(orig_revision).strip()),
                                     '-out%s' % tmp_orig_filename)
 
             # Diff the new file against that.


### PR DESCRIPTION
Change to handle SOS revision as a string where int was previously assumed.  Versions could be of the format 8.1.0/1 etc.  Stripped the version string that was being passed to exportrev command.