### PR TITLE
Use the last line of the identify output to skip debugging messages

### DIFF
--- a/rbtools/clients/mercurial.py
+++ b/rbtools/clients/mercurial.py
@@ -802,7 +802,7 @@ class MercurialClient(BaseSCMClient):
             raise InvalidRevisionSpecError(
                 '"%s" does not appear to be a valid revision' % revision)
         else:
-            return identify.split()[0]
+            return identify.split()[-1]
 
     def _calculate_hgsubversion_repository_info(
         self,


### PR DESCRIPTION
In some cases, when running `rbt post -d ...` the executed `hg identify` will output some debugging info like in this case:

```
hg identify --debug -i --hidden -r s0 --config "extensions.rbtoolsnormalize=c:\Program Files\RBTools\Python\lib\site-packages\rbtools-5.0-py3.10.egg\rbtools\helpers\hgext.py"
obscache is out of date
d3e10a07370b2e864a36fcd013c69e47c102327f
```

This kludge takes the last line of the output instead of the first one to workaround that.