### PR TITLE
Look for the MSVC 2022 version of GNU diff

### DIFF
--- a/rbtools/diffs/tools/backends/gnu.py
+++ b/rbtools/diffs/tools/backends/gnu.py
@@ -282,7 +282,13 @@ class GNUDiffTool(BaseDiffTool):
             )
 
             # Visual Studio 2022 ships a copy of GNU Diff for it's git implementation. Try looking for it.
-            yield r'C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\usr\bin\diff.exe'
+            for edition in ('Community', 'Professional'):
+                yield os.path.join(
+                    r'C:\Program Files\Microsoft Visual Studio\2022',
+                    edition,
+                    r'Common7\IDE\CommonExtensions\Microsoft\TeamFoundation'
+                    r'\Team Explorer\Git\usr\bin\diff.exe'
+                )
 
             # Unity ships GNU diff (or it does at the time of this writing).
             # Try it.

--- a/rbtools/diffs/tools/backends/gnu.py
+++ b/rbtools/diffs/tools/backends/gnu.py
@@ -281,6 +281,9 @@ class GNUDiffTool(BaseDiffTool):
                 for git_path in iter_exes_in_path('git')
             )
 
+            # Visual Studio 2022 ships a copy of GNU Diff for it's git implementation. Try looking for it.
+            yield r'C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\usr\bin\diff.exe'
+
             # Unity ships GNU diff (or it does at the time of this writing).
             # Try it.
             #


### PR DESCRIPTION
Microsoft ship a version of GNU diff.exe with Visual Studio 2022. Add this to the list of locations that we look for a compatible diff program on Windows.